### PR TITLE
use central manged renovate config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,7 @@ pip install -r requirements.txt
 pre-commit install
 ```
 
+## Links
 
-### Releasing
-
-Must be executed from the ``develop`` branch.
-
-```bash
-pre-commit uninstall \
-    && bump2version --tag release --commit \
-    && git checkout master && git merge develop && git checkout develop \
-    && bump2version --no-tag patch --commit \
-    && git push origin master --tags \
-    && git push origin develop \
-    && pre-commit install
-```
+* [nolte/gh-plumbing](https://github.com/nolte/gh-plumbing) for a standardized build process.
+* [hcloud](https://registry.terraform.io/providers/hetznercloud/hcloud/latest/docs) Terraform Provider.

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "config:base"
+    "github>nolte/gh-plumbing//renovate-configs/common#v1.0.5"
   ],
   "pip_requirements": {
     "fileMatch": ["requirements.*.txt"]


### PR DESCRIPTION
### Description

Using [Common](https://github.com/nolte/gh-plumbing/tree/develop/renovate-configs) Renovate config. 

### Acceptance tests
- [X] Have you run the acceptance tests on this branch?

### Documentation
- [X] Have you create or updated the documentation at ``./docs``?
